### PR TITLE
- initial changes

### DIFF
--- a/packages/instrumentation-oracledb/.tav.yml
+++ b/packages/instrumentation-oracledb/.tav.yml
@@ -1,4 +1,4 @@
 oracledb:
     # a sample from supported versions
-  - versions: ">=6.7.0 <8"
+  - versions: ">=6.10.0 <8"
     commands: npm run test

--- a/packages/instrumentation-oracledb/.tav.yml
+++ b/packages/instrumentation-oracledb/.tav.yml
@@ -1,4 +1,4 @@
 oracledb:
     # a sample from supported versions
-  - versions: ">=6.7.0 <7"
+  - versions: ">=6.7.0 <8"
     commands: npm run test

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -142,7 +142,7 @@ currently Release Candidate in the semantic conventions.
 | `db.user` | Removed | Database user name |
 | (not included) | `db.query.text` | SQL text |
 | (not included) | `db.system.name` | Database product identifier |
-| ``db.namespace="<instance>|<pdb>|<service>"`` | ``db.namespace="<dbUniqueName>"`` | Oracle database identifier. Old semconv used a concatenated `instance|pdb|service` value; stable semconv uses `DB_UNIQUE_NAME`. |
+| `db.namespace="<instance>\|<pdb>\|<service>"` | `db.namespace="<dbUniqueName>"` | Oracle database identifier. Old semconv used a concatenated `instance|pdb|service` value; stable semconv uses `DB_UNIQUE_NAME`. |
 | (not included) | `oracle.db.name` | Database name |
 | (not included) | `oracle.db.instance.name` | Oracle instance name |
 | (not included) | `oracle.db.pdb` | Pluggable database name |

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -30,6 +30,10 @@ npm install --save @opentelemetry/instrumentation-oracledb
 - [`oracledb`](https://www.npmjs.com/package/oracledb) versions `>=6.7.0 <8`
 
 ## Usage
+OpenTelemetry OracleInstrumentation allows the user to automatically collect trace data and export them to the backend of choice, to give observability to distributed systems when working with [oracledb](https://www.npmjs.com/package/oracledb). This module works with both Thin and Thick modes of the oracledb
+package, although there may be some caveats with Thick Mode now, which are listed in a later paragraph.
+
+To load a specific plugin (**OracleInstrumentation** in this case), specify it in the configuration of the registerInstrumentations object.
 
 ```js
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
@@ -45,6 +49,11 @@ registerInstrumentations({
   ],
 });
 ```
+
+Caveats with  ``oracledb`` Thick mode:
+
+- RoundTrip Spans will not appear for Thick Mode
+- Hostname will not be available in Thick Mode
 
 This instrumentation supports both Thin and Thick mode in `oracledb`.
 
@@ -89,7 +98,7 @@ For Thin mode, additional internal round-trip spans may be emitted, such as:
 
 - Thin mode emits internal round-trip spans. Thick mode does not.
 - Thick mode does not expose the same low-level network metadata, so attributes
-  such as `server.address`, `server.port`, and `network.transport` may be
+  such as `server.address`, `server.port`, and `network.transport` are
   missing.
 - Oracle connection metadata such as `oracle.db.name`,
   `oracle.db.instance.name`, `oracle.db.pdb`, `oracle.db.domain`, and the final
@@ -119,6 +128,13 @@ To select which semconv version(s) are emitted from this instrumentation, use:
 - `database/dup`: emit both old and stable Database semantic conventions where possible
 - By default, if `OTEL_SEMCONV_STABILITY_OPT_IN` includes neither token, the old semconv is used
 
+`OTEL_SEMCONV_STABILITY_OPT_IN=database` enables the stable database migration
+behavior for core DB attributes. When available, this instrumentation also
+emits Oracle-specific `oracle.db.*` attributes such as
+`oracle.db.domain`, `oracle.db.instance.name`, `oracle.db.name`,
+`oracle.db.pdb`, and `oracle.db.service`; these Oracle-specific attributes are
+currently Release Candidate in the semantic conventions.
+
 ### Attributes collected
 
 | Old semconv | Stable semconv | Short Description |
@@ -126,8 +142,6 @@ To select which semconv version(s) are emitted from this instrumentation, use:
 | `db.user` | Removed | Database user name |
 | `db.statement` | `db.query.text` | SQL text |
 | `db.system` | `db.system.name` | Database product identifier |
-| `net.peer.name` | `server.address` | Remote database host |
-| `net.peer.port` | `server.port` | Remote database port |
 | `db.namespace=<instance|pdb|service>` | `db.namespace=<dbUniqueName>` | Oracle database namespace |
 | (not included) | `oracle.db.name` | Database name |
 | (not included) | `oracle.db.instance.name` | Oracle instance name |

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -87,12 +87,12 @@ For Thin mode, additional internal round-trip spans may be emitted, such as:
 
 | Options | Type | Default | Description |
 | ------- | ---- | ------- | ----------- |
-| [`enhancedDatabaseReporting`](./src/types.ts#L58) | `boolean` | `false` | If true, adds SQL bind values as `db.operation.parameter.<key>` attributes. When enabled, it also records `db.query.text`. This can capture sensitive data and should be used with care. |
-| [`dbStatementDump`](./src/types.ts#L67) | `boolean` | `false` | If true, records the SQL statement as `db.query.text`. |
-| [`requestHook`](./src/types.ts#L76) | `OracleInstrumentationExecutionRequestHook` | `undefined` | Hook for adding custom span attributes based on the query input and connection metadata. |
-| [`responseHook`](./src/types.ts#L84) | `OracleInstrumentationExecutionResponseHook` | `undefined` | Hook for adding custom span attributes based on the database response. |
-| [`requireParentSpan`](./src/types.ts#L92) | `boolean` | `false` | If true, only creates spans when there is an active parent span. |
-| [`propagateTraceContextToSessionAction`](./src/types.ts#L99) | `boolean` | `false` | If true, injects W3C Trace Context into the Oracle `V$SESSION.ACTION` field so database-side tracing can be correlated with application spans. |
+| [`enhancedDatabaseReporting`](./src/types.ts) | `boolean` | `false` | If true, adds SQL bind values as `db.operation.parameter.<key>` attributes. When enabled, it also records `db.query.text`. This can capture sensitive data and should be used with care. |
+| [`dbStatementDump`](./src/types.ts) | `boolean` | `false` | If true, records the SQL statement as `db.query.text`. |
+| [`requestHook`](./src/types.ts) | `OracleInstrumentationExecutionRequestHook` | `undefined` | Hook for adding custom span attributes based on the query input and connection metadata. |
+| [`responseHook`](./src/types.ts) | `OracleInstrumentationExecutionResponseHook` | `undefined` | Hook for adding custom span attributes based on the database response. |
+| [`requireParentSpan`](./src/types.ts) | `boolean` | `false` | If true, only creates spans when there is an active parent span. |
+| [`propagateTraceContextToSessionAction`](./src/types.ts) | `boolean` | `false` | If true, injects W3C Trace Context into the Oracle `V$SESSION.ACTION` field so database-side tracing can be correlated with application spans. |
 
 ## OracleDB-specific Notes
 

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -73,7 +73,7 @@ execution, and LOB operations.
 | `oracledb.Connection.createLob` | Temporary LOB creation | When `connection.createLob()` is called |
 | `oracledb.Lob.getData` | LOB data read | When `lob.getData()` is called |
 
-For Thin mode, additional internal round-trip spans may be emitted, such as:
+For Thin mode, additional internal round-trip spans will be emitted, such as:
 
 - `oracledb.FastAuthMessage`
 - `oracledb.AuthMessage`
@@ -140,9 +140,9 @@ currently Release Candidate in the semantic conventions.
 | Old semconv | Stable semconv | Short Description |
 | ----------- | -------------- | ----------------- |
 | `db.user` | Removed | Database user name |
-| `db.statement` | `db.query.text` | SQL text |
-| `db.system` | `db.system.name` | Database product identifier |
-| `db.namespace=<instance|pdb|service>` | `db.namespace=<dbUniqueName>` | Oracle database namespace |
+| (not included) | `db.query.text` | SQL text |
+| (not included) | `db.system.name` | Database product identifier |
+| ``db.namespace="<instance>|<pdb>|<service>"`` | ``db.namespace="<dbUniqueName>"`` | Oracle database identifier. Old semconv used a concatenated `instance|pdb|service` value; stable semconv uses `DB_UNIQUE_NAME`. |
 | (not included) | `oracle.db.name` | Database name |
 | (not included) | `oracle.db.instance.name` | Oracle instance name |
 | (not included) | `oracle.db.pdb` | Pluggable database name |

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -1,11 +1,21 @@
-# OpenTelemetry oracledb Instrumentation for Node.js
+# OpenTelemetry OracleDB Instrumentation for Node.js
 
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides automatic instrumentation for the [`oracledb`](https://www.npmjs.com/package/oracledb) module, which may be loaded using the [`@opentelemetry/sdk-trace-node`](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node) package and is included in the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle.
+This module provides automatic instrumentation for the
+[`oracledb`](https://www.npmjs.com/package/oracledb) module, which may be
+loaded using the
+[`@opentelemetry/sdk-trace-node`](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node)
+package and is included in the
+[`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)
+bundle.
 
-If total installation size is not constrained, it is recommended to use the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle with [@opentelemetry/sdk-node](`https://www.npmjs.com/package/@opentelemetry/sdk-node`) for the most seamless instrumentation experience.
+If total installation size is not constrained, it is recommended to use the
+[`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)
+bundle with
+[`@opentelemetry/sdk-node`](https://www.npmjs.com/package/@opentelemetry/sdk-node)
+for the most seamless instrumentation experience.
 
 Compatible with OpenTelemetry JS API and SDK `1.0+`.
 
@@ -17,14 +27,9 @@ npm install --save @opentelemetry/instrumentation-oracledb
 
 ## Supported Versions
 
-- [`oracledb`](https://www.npmjs.com/package/oracledb) versions `>=6.7.0 <7`
+- [`oracledb`](https://www.npmjs.com/package/oracledb) versions `>=6.7.0 <8`
 
 ## Usage
-
-OpenTelemetry OracleInstrumentation allows the user to automatically collect trace data and export them to the backend of choice, to give observability to distributed systems when working with [oracledb](https://www.npmjs.com/package/oracledb). This module works with both Thin and Thick modes of the oracledb
-package, although there may be some caveats with Thick Mode now, which are listed in a later paragraph.
-
-To load a specific plugin (**OracleInstrumentation** in this case), specify it in the configuration of the registerInstrumentations object.
 
 ```js
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
@@ -38,30 +43,133 @@ registerInstrumentations({
   instrumentations: [
     new OracleInstrumentation(),
   ],
-})
+});
 ```
 
-Caveats with  ``oracledb`` Thick mode:
+This instrumentation supports both Thin and Thick mode in `oracledb`.
 
-- RoundTrip Spans will not appear for Thick Mode
-- Hostname will not be available in Thick Mode
+### Span Types Created
 
-### Oracle Instrumentation Options
+This instrumentation creates spans for connection establishment, query
+execution, and LOB operations.
+
+| Span Name | Description | When Created |
+| --------- | ----------- | ------------ |
+| `oracledb.getConnection` | Standalone connection acquisition | When `oracledb.getConnection()` is called |
+| `oracledb.createPool` | Pool creation | When `oracledb.createPool()` is called |
+| `oracledb.Pool.getConnection` | Pool connection acquisition | When `pool.getConnection()` is called |
+| `oracledb.Connection.execute:<OPERATION> <db.namespace>` | SQL execution | When `connection.execute()` is called |
+| `oracledb.Connection.executeMany:<OPERATION> <db.namespace>` | Batch SQL execution | When `connection.executeMany()` is called |
+| `oracledb.Connection.close` | Connection close | When `connection.close()` is called |
+| `oracledb.Connection.createLob` | Temporary LOB creation | When `connection.createLob()` is called |
+| `oracledb.Lob.getData` | LOB data read | When `lob.getData()` is called |
+
+For Thin mode, additional internal round-trip spans may be emitted, such as:
+
+- `oracledb.FastAuthMessage`
+- `oracledb.AuthMessage`
+- `oracledb.ProtocolMessage`
+- `oracledb.DataTypeMessage`
+- `oracledb.ExecuteMessage`
+- `oracledb.LogOffMessage`
+- `oracledb.LobOpMessage`
+
+### OracleDB Instrumentation Options
 
 | Options | Type | Default | Description |
 | ------- | ---- | ------- | ----------- |
-| `enhancedDatabaseReporting` | `boolean` | `false` | If true, details about the sql statement's bind values (being set on parameters ``db.operation.parameter.<key>``) and the sql string (being set on parameter ``db.query.text``) will be attached to the spans generated |
-| `dbStatementDump` | `boolean` | `false` | If true, ``db.query.text`` will contain the sql string in the spans generated |
-| `requestHook` | `OracleInstrumentationExecutionRequestHook` (function) | | Function for adding custom span attributes using information about the data for the sql statement being executed |
-| `responseHook` | `OracleInstrumentationExecutionResponseHook` (function) | | Function for adding custom span attributes from the db response |
-| `requireParentSpan` | `boolean` | `false` | If true, requires a parent span to create new spans |
-| `propagateTraceContextToSessionAction` | `boolean` | `false` | If true, injects the W3C Trace Context into the Oracle V$SESSION.ACTION field. This allows the OpenTelemetry Collector to correlate application traces with database server spans. |
+| [`enhancedDatabaseReporting`](./src/types.ts#L58) | `boolean` | `false` | If true, adds SQL bind values as `db.operation.parameter.<key>` attributes. When enabled, it also records `db.query.text`. This can capture sensitive data and should be used with care. |
+| [`dbStatementDump`](./src/types.ts#L67) | `boolean` | `false` | If true, records the SQL statement as `db.query.text`. |
+| [`requestHook`](./src/types.ts#L76) | `OracleInstrumentationExecutionRequestHook` | `undefined` | Hook for adding custom span attributes based on the query input and connection metadata. |
+| [`responseHook`](./src/types.ts#L84) | `OracleInstrumentationExecutionResponseHook` | `undefined` | Hook for adding custom span attributes based on the database response. |
+| [`requireParentSpan`](./src/types.ts#L92) | `boolean` | `false` | If true, only creates spans when there is an active parent span. |
+| [`propagateTraceContextToSessionAction`](./src/types.ts#L99) | `boolean` | `false` | If true, injects W3C Trace Context into the Oracle `V$SESSION.ACTION` field so database-side tracing can be correlated with application spans. |
+
+## OracleDB-specific Notes
+
+- Thin mode emits internal round-trip spans. Thick mode does not.
+- Thick mode does not expose the same low-level network metadata, so attributes
+  such as `server.address`, `server.port`, and `network.transport` may be
+  missing.
+- Oracle connection metadata such as `oracle.db.name`,
+  `oracle.db.instance.name`, `oracle.db.pdb`, `oracle.db.domain`, and the final
+  effective `oracle.db.service` are only available after connection metadata has
+  been resolved by the driver.
+- Failed logins may still include the attempted service name, which is useful
+  for debugging connection issues.
+
+## Semantic Conventions
+
+Prior to stable Database semantic conventions, this instrumentation used older
+database attributes such as `db.user`, `db.statement`, and an Oracle-specific
+`db.namespace` meaning that combined multiple connection properties.
+
+Database semantic conventions were stabilized in v1.34.0, and a
+[migration process](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/db-migration.md)
+was defined. `@opentelemetry/instrumentation-oracledb` supports migration using
+the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
+The intent is to provide an approximate 6 month time window for users of this
+instrumentation to migrate to the new Database semconv, after which a new minor
+version will use the new semconv by default and drop support for the old
+semconv.
+
+To select which semconv version(s) are emitted from this instrumentation, use:
+
+- `database`: emit the new stable Database semantic conventions
+- `database/dup`: emit both old and stable Database semantic conventions where possible
+- By default, if `OTEL_SEMCONV_STABILITY_OPT_IN` includes neither token, the old semconv is used
+
+### Attributes collected
+
+| Old semconv | Stable semconv | Short Description |
+| ----------- | -------------- | ----------------- |
+| `db.user` | Removed | Database user name |
+| `db.statement` | `db.query.text` | SQL text |
+| `db.system` | `db.system.name` | Database product identifier |
+| `net.peer.name` | `server.address` | Remote database host |
+| `net.peer.port` | `server.port` | Remote database port |
+| `db.namespace=<instance|pdb|service>` | `db.namespace=<dbUniqueName>` | Oracle database namespace |
+| (not included) | `oracle.db.name` | Database name |
+| (not included) | `oracle.db.instance.name` | Oracle instance name |
+| (not included) | `oracle.db.pdb` | Pluggable database name |
+| (not included) | `oracle.db.domain` | Database domain |
+| (not included) | `oracle.db.service` | Effective Oracle service name |
+
+### `db.namespace` migration note
+
+OracleDB has a special migration constraint: both the old and stable
+definitions use the same `db.namespace` key with different meanings.
+
+- Old meaning: a concatenated value derived from instance name, PDB name, and
+  service name
+- Stable meaning: the Oracle database unique identifier (`DB_UNIQUE_NAME`)
+
+Because a span cannot carry two different values for the same attribute key,
+`OTEL_SEMCONV_STABILITY_OPT_IN=database/dup` keeps the old `db.namespace`
+meaning while also emitting the new `oracle.db.*` attributes. To switch
+`db.namespace` itself to the stable meaning, use:
+
+```bash
+OTEL_SEMCONV_STABILITY_OPT_IN=database
+```
+
+### Upgrading Semantic Conventions
+
+When upgrading to the stable semantic conventions, it is recommended to do so
+in the following order:
+
+1. Upgrade `@opentelemetry/instrumentation-oracledb` to the latest version
+2. Set `OTEL_SEMCONV_STABILITY_OPT_IN=database/dup`
+3. Update dashboards, alerts, processors, and queries to understand the new
+   `oracle.db.*` attributes and the eventual `db.namespace` change
+4. Set `OTEL_SEMCONV_STABILITY_OPT_IN=database`
 
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For help or feedback on this project, join us in
+  [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/packages/instrumentation-oracledb/README.md
+++ b/packages/instrumentation-oracledb/README.md
@@ -137,17 +137,32 @@ currently Release Candidate in the semantic conventions.
 
 ### Attributes collected
 
-| Old semconv | Stable semconv | Short Description |
-| ----------- | -------------- | ----------------- |
+Attributes affected by `OTEL_SEMCONV_STABILITY_OPT_IN=database`:
+
+| Default / old mode | Stable mode | Short Description |
+| ------------------ | ----------- | ----------------- |
 | `db.user` | Removed | Database user name |
-| (not included) | `db.query.text` | SQL text |
-| (not included) | `db.system.name` | Database product identifier |
-| `db.namespace="<instance>\|<pdb>\|<service>"` | `db.namespace="<dbUniqueName>"` | Oracle database identifier. Old semconv used a concatenated `instance|pdb|service` value; stable semconv uses `DB_UNIQUE_NAME`. |
-| (not included) | `oracle.db.name` | Database name |
-| (not included) | `oracle.db.instance.name` | Oracle instance name |
-| (not included) | `oracle.db.pdb` | Pluggable database name |
-| (not included) | `oracle.db.domain` | Database domain |
-| (not included) | `oracle.db.service` | Effective Oracle service name |
+| `db.namespace="<instance>\|<pdb>\|<service>"` | `db.namespace="<dbUniqueName>"` | Oracle database identifier. Default / old mode uses a concatenated `instance|pdb|service` value; stable mode uses `DB_UNIQUE_NAME`. |
+
+Attributes emitted independently of the `database` opt-in:
+
+| Attribute | Short Description |
+| --------- | ----------------- |
+| `db.system.name` | Database product identifier |
+| `network.transport` | Network transport |
+| `server.address` | Remote database host |
+| `server.port` | Remote database port |
+| `db.query.text` | SQL text when `dbStatementDump` or `enhancedDatabaseReporting` is enabled |
+
+Oracle-specific attributes emitted with `database` / `database/dup` when available:
+
+| Attribute | Short Description |
+| --------- | ----------------- |
+| `oracle.db.name` | Database name |
+| `oracle.db.instance.name` | Oracle instance name |
+| `oracle.db.pdb` | Pluggable database name |
+| `oracle.db.domain` | Database domain |
+| `oracle.db.service` | Effective Oracle service name |
 
 ### `db.namespace` migration note
 

--- a/packages/instrumentation-oracledb/package.json
+++ b/packages/instrumentation-oracledb/package.json
@@ -59,7 +59,7 @@
     "@opentelemetry/contrib-test-utils": "^0.66.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
-    "oracledb": "^6.7.0"
+    "oracledb": "^7.0.0"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.219.0",

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import {
+  safeExecuteInTheMiddle,
+  SemconvStability,
+} from '@opentelemetry/instrumentation';
 import {
   Span,
   SpanStatusCode,
@@ -26,8 +29,13 @@ import {
   ATTR_NETWORK_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import {
-  ATTR_DB_USER,
   ATTR_DB_OPERATION_PARAMETER,
+  ATTR_DB_USER,
+  ATTR_ORACLE_DB_DOMAIN,
+  ATTR_ORACLE_DB_INSTANCE_NAME,
+  ATTR_ORACLE_DB_NAME,
+  ATTR_ORACLE_DB_PDB,
+  ATTR_ORACLE_DB_SERVICE,
   DB_SYSTEM_NAME_VALUE_ORACLE_DB,
 } from './semconv';
 
@@ -92,9 +100,19 @@ export function getOracleTelemetryTraceHandlerClass(
       );
     }
 
-    // It returns db.namespace as mentioned in semantic conventions
-    // Ex: ORCL1|PDB1|db_high.adb.oraclecloud.com
-    private _getDBNameSpace(
+    private _usesOldDbSemconv() {
+      return Boolean(
+        this._instrumentConfig.dbSemconvStability! & SemconvStability.OLD
+      );
+    }
+
+    private _usesStableDbSemconv() {
+      return Boolean(
+        this._instrumentConfig.dbSemconvStability! & SemconvStability.STABLE
+      );
+    }
+
+    private _getOldDbNamespace(
       instanceName?: string,
       pdbName?: string,
       serviceName?: string
@@ -105,21 +123,58 @@ export function getOracleTelemetryTraceHandlerClass(
       return `${instanceName ?? ''}|${pdbName ?? ''}|${serviceName ?? ''}`;
     }
 
+    private _hasValue(value: string | number | undefined) {
+      return value !== undefined && value !== '';
+    }
+
     // Returns the connection related Attributes for
     // semantic standards and module custom keys.
     private _getConnectionSpanAttributes(config: SpanConnectionConfig) {
-      return {
+      const attributes: Record<string, string | number | undefined> = {
         [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
         [ATTR_NETWORK_TRANSPORT]: config.protocol,
-        [ATTR_DB_USER]: config.user,
-        [ATTR_DB_NAMESPACE]: this._getDBNameSpace(
-          config.instanceName,
-          config.pdbName,
-          config.serviceName
-        ),
         [ATTR_SERVER_ADDRESS]: config.hostName,
         [ATTR_SERVER_PORT]: config.port,
       };
+
+      if (this._usesOldDbSemconv()) {
+        if (this._hasValue(config.user)) {
+          attributes[ATTR_DB_USER] = config.user;
+        }
+        const oldDbNamespace = this._getOldDbNamespace(
+          config.instanceName,
+          config.pdbName,
+          config.serviceName
+        );
+        if (oldDbNamespace !== undefined) {
+          attributes[ATTR_DB_NAMESPACE] = oldDbNamespace;
+        }
+      }
+
+      if (this._usesStableDbSemconv()) {
+        // In database/dup mode, db.namespace keeps the old meaning because
+        // both meanings cannot coexist on the same span under one key.
+        if (!this._usesOldDbSemconv() && this._hasValue(config.dbUniqueName)) {
+          attributes[ATTR_DB_NAMESPACE] = config.dbUniqueName;
+        }
+        if (this._hasValue(config.dbName)) {
+          attributes[ATTR_ORACLE_DB_NAME] = config.dbName;
+        }
+        if (this._hasValue(config.domainName)) {
+          attributes[ATTR_ORACLE_DB_DOMAIN] = config.domainName;
+        }
+        if (this._hasValue(config.pdbName)) {
+          attributes[ATTR_ORACLE_DB_PDB] = config.pdbName;
+        }
+        if (this._hasValue(config.instanceName)) {
+          attributes[ATTR_ORACLE_DB_INSTANCE_NAME] = config.instanceName;
+        }
+        if (this._hasValue(config.serviceName)) {
+          attributes[ATTR_ORACLE_DB_SERVICE] = config.serviceName;
+        }
+      }
+
+      return attributes;
     }
 
     // It returns true if object is of type oracledb.Lob.
@@ -286,8 +341,13 @@ export function getOracleTelemetryTraceHandlerClass(
         return;
       }
 
-      const { instanceName, pdbName, serviceName } = connectLevelConfig;
-      const dbName = this._getDBNameSpace(instanceName, pdbName, serviceName);
+      const dbName = this._usesStableDbSemconv()
+        ? connectLevelConfig.dbUniqueName
+        : this._getOldDbNamespace(
+            connectLevelConfig.instanceName,
+            connectLevelConfig.pdbName,
+            connectLevelConfig.serviceName
+          );
       const sqlCommand =
         callLevelConfig?.statement?.split(' ')[0].toUpperCase() || '';
       userContext.span.updateName(

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -341,6 +341,14 @@ export function getOracleTelemetryTraceHandlerClass(
         return;
       }
 
+      // Some older node-oracledb versions do not populate
+      // callLevelConfig.statement for executeMany round trips,
+      // so fall back to the original SQL argument.
+      const sqlStatement =
+        callLevelConfig?.statement ??
+        (typeof traceContext.args?.[0] === 'string'
+          ? traceContext.args[0]
+          : undefined);
       const dbName = this._usesStableDbSemconv()
         ? connectLevelConfig.dbUniqueName
         : this._getOldDbNamespace(
@@ -348,10 +356,14 @@ export function getOracleTelemetryTraceHandlerClass(
             connectLevelConfig.pdbName,
             connectLevelConfig.serviceName
           );
+      // Prefer the SQL text for the verb, then fall back to the operation
+      // field when the trace payload omits the statement.
       const sqlCommand =
-        callLevelConfig?.statement?.split(' ')[0].toUpperCase() || '';
+        sqlStatement?.split(' ')[0].toUpperCase() ||
+        callLevelConfig?.operation ||
+        '';
       userContext.span.updateName(
-        `${operation}:${sqlCommand}${dbName && ` ${dbName}`}`
+        `${operation}:${sqlCommand}${dbName ? ` ${dbName}` : ''}`
       );
     }
 

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -356,12 +356,9 @@ export function getOracleTelemetryTraceHandlerClass(
             connectLevelConfig.pdbName,
             connectLevelConfig.serviceName
           );
-      // Prefer the SQL text for the verb, then fall back to the operation
-      // field when the trace payload omits the statement.
-      const sqlCommand =
-        sqlStatement?.split(' ')[0].toUpperCase() ||
-        callLevelConfig?.operation ||
-        '';
+      // Prefer the SQL text for the verb. When the trace payload omits the
+      // statement, the fallback above uses the original SQL argument.
+      const sqlCommand = sqlStatement?.split(' ')[0].toUpperCase() || '';
       userContext.span.updateName(
         `${operation}:${sqlCommand}${dbName ? ` ${dbName}` : ''}`
       );

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -100,16 +100,16 @@ export function getOracleTelemetryTraceHandlerClass(
       );
     }
 
+    private get _stability(): SemconvStability {
+      return this._instrumentConfig.dbSemconvStability ?? SemconvStability.OLD;
+    }
+
     private _usesOldDbSemconv() {
-      return Boolean(
-        this._instrumentConfig.dbSemconvStability! & SemconvStability.OLD
-      );
+      return Boolean(this._stability & SemconvStability.OLD);
     }
 
     private _usesStableDbSemconv() {
-      return Boolean(
-        this._instrumentConfig.dbSemconvStability! & SemconvStability.STABLE
-      );
+      return Boolean(this._stability & SemconvStability.STABLE);
     }
 
     private _getOldDbNamespace(
@@ -146,7 +146,7 @@ export function getOracleTelemetryTraceHandlerClass(
           config.pdbName,
           config.serviceName
         );
-        if (oldDbNamespace !== undefined) {
+        if (oldDbNamespace && oldDbNamespace !== '||') {
           attributes[ATTR_DB_NAMESPACE] = oldDbNamespace;
         }
       }

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -126,6 +126,9 @@ export function getOracleTelemetryTraceHandlerClass(
     // Returns the connection related Attributes for
     // semantic standards and module custom keys.
     private _getConnectionSpanAttributes(config: SpanConnectionConfig) {
+      // These attributes are emitted independently of the db semconv opt-in.
+      // The db semconv migration in this instrumentation is centered on
+      // db.user removal, db.namespace meaning, and Oracle-specific split attrs.
       const attributes: Record<string, string | number | undefined> = {
         [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
         [ATTR_NETWORK_TRANSPORT]: config.protocol,

--- a/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
+++ b/packages/instrumentation-oracledb/src/OracleTelemetryTraceHandler.ts
@@ -123,10 +123,6 @@ export function getOracleTelemetryTraceHandlerClass(
       return `${instanceName ?? ''}|${pdbName ?? ''}|${serviceName ?? ''}`;
     }
 
-    private _hasValue(value: string | number | undefined) {
-      return value !== undefined && value !== '';
-    }
-
     // Returns the connection related Attributes for
     // semantic standards and module custom keys.
     private _getConnectionSpanAttributes(config: SpanConnectionConfig) {
@@ -138,7 +134,7 @@ export function getOracleTelemetryTraceHandlerClass(
       };
 
       if (this._usesOldDbSemconv()) {
-        if (this._hasValue(config.user)) {
+        if (config.user) {
           attributes[ATTR_DB_USER] = config.user;
         }
         const oldDbNamespace = this._getOldDbNamespace(
@@ -154,22 +150,22 @@ export function getOracleTelemetryTraceHandlerClass(
       if (this._usesStableDbSemconv()) {
         // In database/dup mode, db.namespace keeps the old meaning because
         // both meanings cannot coexist on the same span under one key.
-        if (!this._usesOldDbSemconv() && this._hasValue(config.dbUniqueName)) {
+        if (!this._usesOldDbSemconv() && config.dbUniqueName) {
           attributes[ATTR_DB_NAMESPACE] = config.dbUniqueName;
         }
-        if (this._hasValue(config.dbName)) {
+        if (config.dbName) {
           attributes[ATTR_ORACLE_DB_NAME] = config.dbName;
         }
-        if (this._hasValue(config.domainName)) {
+        if (config.domainName) {
           attributes[ATTR_ORACLE_DB_DOMAIN] = config.domainName;
         }
-        if (this._hasValue(config.pdbName)) {
+        if (config.pdbName) {
           attributes[ATTR_ORACLE_DB_PDB] = config.pdbName;
         }
-        if (this._hasValue(config.instanceName)) {
+        if (config.instanceName) {
           attributes[ATTR_ORACLE_DB_INSTANCE_NAME] = config.instanceName;
         }
-        if (this._hasValue(config.serviceName)) {
+        if (config.serviceName) {
           attributes[ATTR_ORACLE_DB_SERVICE] = config.serviceName;
         }
       }

--- a/packages/instrumentation-oracledb/src/instrumentation.ts
+++ b/packages/instrumentation-oracledb/src/instrumentation.ts
@@ -22,10 +22,12 @@ export class OracleInstrumentation extends InstrumentationBase {
 
   constructor(config: OracleInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
-    this._setSemconvStabilityFromEnv();
+    this._setSemconvStability();
   }
 
-  private _setSemconvStabilityFromEnv() {
+  private _setSemconvStability() {
+    // Semconv mode follows the public process-level opt-in contract and is
+    // resolved once at construction time from the environment.
     this._dbSemconvStability = semconvStabilityFromStr(
       'database',
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN
@@ -74,7 +76,8 @@ export class OracleInstrumentation extends InstrumentationBase {
   override setConfig(config: OracleInstrumentationConfig = {}) {
     super.setConfig(config);
 
-    // update the config in OracleTelemetryTraceHandler obj.
+    // Semconv mode is resolved at construction time and is not mutated by
+    // runtime config updates.
     this._tmHandler?.setInstrumentConfig({
       ...this._config,
       dbSemconvStability: this._dbSemconvStability,

--- a/packages/instrumentation-oracledb/src/instrumentation.ts
+++ b/packages/instrumentation-oracledb/src/instrumentation.ts
@@ -7,6 +7,8 @@
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
+  SemconvStability,
+  semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
 import type * as oracleDBTypes from 'oracledb';
 import { OracleInstrumentationConfig } from './types';
@@ -16,15 +18,24 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
 export class OracleInstrumentation extends InstrumentationBase {
   private _tmHandler: any;
+  private _dbSemconvStability!: SemconvStability;
 
   constructor(config: OracleInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
+    this._setSemconvStabilityFromEnv();
+  }
+
+  private _setSemconvStabilityFromEnv() {
+    this._dbSemconvStability = semconvStabilityFromStr(
+      'database',
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN
+    );
   }
 
   protected init() {
     const moduleOracleDB = new InstrumentationNodeModuleDefinition(
       'oracledb',
-      ['>= 6.7 < 7'],
+      ['>= 6.7 < 8'],
       (moduleExports: typeof oracleDBTypes) => {
         if (!moduleExports) {
           return;
@@ -34,7 +45,10 @@ export class OracleInstrumentation extends InstrumentationBase {
           (moduleExports as any).traceHandler.setTraceInstance();
           this._tmHandler = null;
         }
-        const config = this.getConfig();
+        const config = {
+          ...this.getConfig(),
+          dbSemconvStability: this._dbSemconvStability,
+        };
         const thClass = getOracleTelemetryTraceHandlerClass(moduleExports);
         if (thClass) {
           const obj = new thClass(() => this.tracer, config);
@@ -61,6 +75,9 @@ export class OracleInstrumentation extends InstrumentationBase {
     super.setConfig(config);
 
     // update the config in OracleTelemetryTraceHandler obj.
-    this._tmHandler?.setInstrumentConfig(this._config);
+    this._tmHandler?.setInstrumentConfig({
+      ...this._config,
+      dbSemconvStability: this._dbSemconvStability,
+    });
   }
 }

--- a/packages/instrumentation-oracledb/src/semconv.ts
+++ b/packages/instrumentation-oracledb/src/semconv.ts
@@ -40,6 +40,33 @@ export const ATTR_DB_OPERATION_PARAMETER = (key: string) =>
 export const ATTR_DB_USER = 'db.user' as const;
 
 /**
+ * The database domain associated with the connection.
+ */
+export const ATTR_ORACLE_DB_DOMAIN = 'oracle.db.domain' as const;
+
+/**
+ * The instance name associated with the connection in an Oracle Real
+ * Application Clusters environment.
+ */
+export const ATTR_ORACLE_DB_INSTANCE_NAME =
+  'oracle.db.instance.name' as const;
+
+/**
+ * The database name associated with the connection.
+ */
+export const ATTR_ORACLE_DB_NAME = 'oracle.db.name' as const;
+
+/**
+ * The pluggable database (PDB) name associated with the connection.
+ */
+export const ATTR_ORACLE_DB_PDB = 'oracle.db.pdb' as const;
+
+/**
+ * The service name currently associated with the database connection.
+ */
+export const ATTR_ORACLE_DB_SERVICE = 'oracle.db.service' as const;
+
+/**
  * Enum value "oracle.db" for attribute {@link ATTR_DB_SYSTEM_NAME}.
  *
  * [Oracle Database](https://www.oracle.com/database/)

--- a/packages/instrumentation-oracledb/src/types.ts
+++ b/packages/instrumentation-oracledb/src/types.ts
@@ -50,9 +50,8 @@ export interface OracleInstrumentationConfig extends InstrumentationConfig {
   /**
    * Internal-only override for DB semconv migration mode.
    *
-   * Production users should control semconv selection with
-   * OTEL_SEMCONV_STABILITY_OPT_IN. This field exists for
-   * instrumentation internals and tests.
+   * users should control semconv selection with
+   * OTEL_SEMCONV_STABILITY_OPT_IN env.
    *
    * @internal
    */

--- a/packages/instrumentation-oracledb/src/types.ts
+++ b/packages/instrumentation-oracledb/src/types.ts
@@ -48,8 +48,11 @@ export interface OracleInstrumentationExecutionResponseHook {
 
 export interface OracleInstrumentationConfig extends InstrumentationConfig {
   /**
-   * Internal DB semconv migration mode derived from
-   * OTEL_SEMCONV_STABILITY_OPT_IN.
+   * Internal-only override for DB semconv migration mode.
+   *
+   * Production users should control semconv selection with
+   * OTEL_SEMCONV_STABILITY_OPT_IN. This field exists for
+   * instrumentation internals and tests.
    *
    * @internal
    */

--- a/packages/instrumentation-oracledb/src/types.ts
+++ b/packages/instrumentation-oracledb/src/types.ts
@@ -5,7 +5,10 @@
  */
 
 import type * as api from '@opentelemetry/api';
-import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import {
+  InstrumentationConfig,
+  SemconvStability,
+} from '@opentelemetry/instrumentation';
 
 // Captures connection related span data
 export interface SpanConnectionConfig {
@@ -15,9 +18,12 @@ export interface SpanConnectionConfig {
   port?: number;
   user?: string;
   protocol?: string;
+  dbName?: string;
   instanceName?: string;
   serverMode?: string;
   pdbName?: string;
+  domainName?: string;
+  dbUniqueName?: string;
   poolMin?: number;
   poolMax?: number;
   poolIncrement?: number;
@@ -41,6 +47,14 @@ export interface OracleInstrumentationExecutionResponseHook {
 }
 
 export interface OracleInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Internal DB semconv migration mode derived from
+   * OTEL_SEMCONV_STABILITY_OPT_IN.
+   *
+   * @internal
+   */
+  dbSemconvStability?: SemconvStability;
+
   /**
    * If true, an attribute containing the execute method
    * bind values will be attached the spans generated.

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -96,8 +96,8 @@ const hostname = 'localhost';
 const pno = 1521;
 const serviceName = 'FREEPDB1';
 
-function isOracleDBPre7(): boolean {
-  return oracledb.version <= 61000;
+function isOracleDB610(): boolean {
+  return oracledb.version === 61000;
 }
 
 let serverVersion = 2304000000; // DB version.
@@ -201,8 +201,6 @@ if (process.env.NODE_ORACLEDB_DRIVER_MODE === 'thick') {
 function updateAttrSpanList(connection: oracledb.Connection) {
   serverVersion = connection.oracleServerVersion;
   const extendedConnection = connection as any;
-  const resolvedConnectMetadataAvailableDuringHandshake =
-    oracledb.version < 61000;
   const connectSpanAttributes: Record<string, string | number> = {};
 
   let attributes: Record<string, string | number>;
@@ -222,29 +220,19 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   }
   if (extendedConnection.pdbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
-  } else if (isOracleDBPre7() && connection.dbName) {
+  } else if (isOracleDB610() && connection.dbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = connection.dbName;
   }
   if (connection.serviceName) {
     connectSpanAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
   }
-  if (
-    resolvedConnectMetadataAvailableDuringHandshake &&
-    !isOracleDBPre7() &&
-    connection.dbName
-  ) {
+  if (!isOracleDB610() && connection.dbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
   }
-  if (
-    resolvedConnectMetadataAvailableDuringHandshake &&
-    extendedConnection.domainName
-  ) {
+  if (!isOracleDB610() && extendedConnection.domainName) {
     connectSpanAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConnection.domainName;
   }
-  if (
-    resolvedConnectMetadataAvailableDuringHandshake &&
-    extendedConnection.dbUniqueName
-  ) {
+  if (!isOracleDB610() && extendedConnection.dbUniqueName) {
     connectSpanAttributes[ATTR_DB_NAMESPACE] = `${extendedConnection.dbUniqueName}`;
   }
 
@@ -261,15 +249,10 @@ function updateAttrSpanList(connection: oracledb.Connection) {
       // for round trips.
       connAttrList.push({ ...attributes }); // FastAuth standalone
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES }); // FastAuth pool
-      if (oracledb.version < 61000) {
-        connAttrList.push({ ...connAttributes }); // OAUTH
-        poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES }); // OAUTH
-      } else {
-        // From oracledb version 6.10 onwards, the db instance name is not populated
-        // until all validations for connection establishment is done.
-        connAttrList.push({ ...attributes }); // OAUTH
-        poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES }); // OAUTH
-      }
+      // From oracledb version 6.10 onwards, the db instance name is not
+      // populated until all validations for connection establishment are done.
+      connAttrList.push({ ...attributes }); // OAUTH
+      poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES }); // OAUTH
       failedConnAttrList = [...connAttrList];
       failedConnAttrList[2] = { ...CONN_FAILED_ATTRIBUTES };
       failedConnAttrList[1] = { ...attributes };
@@ -288,13 +271,8 @@ function updateAttrSpanList(connection: oracledb.Connection) {
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
-      if (oracledb.version < 61000) {
-        connAttrList.push({ ...attributes });
-        poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
-      } else {
-        connAttrList.push({ ...connectSpanAttributes });
-        poolConnAttrList.push({ ...connectSpanAttributes, ...POOL_ATTRIBUTES });
-      }
+      connAttrList.push({ ...connectSpanAttributes });
+      poolConnAttrList.push({ ...connectSpanAttributes, ...POOL_ATTRIBUTES });
       failedConnAttrList = [...connAttrList];
       failedConnAttrList[4] = { ...CONN_FAILED_ATTRIBUTES };
       failedConnAttrList[3] = { ...attributes };
@@ -574,12 +552,12 @@ describe('oracledb', () => {
     if (oracledb.thin && extendedConn.protocol) {
       connAttributes[ATTR_NETWORK_TRANSPORT] = extendedConn.protocol;
     }
-    if (connection.dbName && !isOracleDBPre7()) {
+    if (connection.dbName && !isOracleDB610()) {
       connAttributes[ATTR_ORACLE_DB_NAME] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
     }
-    if (extendedConn.domainName && !isOracleDBPre7()) {
+    if (extendedConn.domainName && !isOracleDB610()) {
       connAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConn.domainName;
     }
     if (connection.instanceName) {
@@ -587,7 +565,7 @@ describe('oracledb', () => {
     }
     if (extendedConn.pdbName) {
       connAttributes[ATTR_ORACLE_DB_PDB] = extendedConn.pdbName;
-    } else if (connection.dbName && isOracleDBPre7()) {
+    } else if (connection.dbName && isOracleDB610()) {
       connAttributes[ATTR_ORACLE_DB_PDB] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
@@ -595,7 +573,7 @@ describe('oracledb', () => {
     if (connection.serviceName) {
       connAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
     }
-    if (extendedConn.dbUniqueName && !isOracleDBPre7()) {
+    if (extendedConn.dbUniqueName && !isOracleDB610()) {
       connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
     }
     poolAttributes = { ...connAttributes, ...POOL_ATTRIBUTES };
@@ -1468,7 +1446,7 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds)', async () => {
       const span = tracer.startSpan('test span');
-      const executeManyRoundTripCommand = isOracleDBPre7()
+      const executeManyRoundTripCommand = isOracleDB610()
         ? ''
         : 'INSERT';
       const executeManyPublicCommand = 'INSERT';
@@ -1481,7 +1459,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!isOracleDBPre7()) {
+      if (!isOracleDB610()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
 
@@ -1515,7 +1493,7 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds) with out parent span', async () => {
       instrumentation.enable();
-      const executeManyRoundTripCommand = isOracleDBPre7()
+      const executeManyRoundTripCommand = isOracleDB610()
         ? ''
         : 'INSERT';
       const executeManyPublicCommand = 'INSERT';
@@ -1528,7 +1506,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!isOracleDBPre7()) {
+      if (!isOracleDB610()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
       const res = await connection.executeMany<Array<string>>(sqlInsert, binds);

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -493,6 +493,10 @@ describe('DB semconv migration', () => {
     );
 
     assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
+    assert.strictEqual(
+      attributes[ATTR_DB_SYSTEM_NAME],
+      DB_SYSTEM_NAME_VALUE_ORACLE_DB
+    );
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
     assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
     assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');
@@ -511,6 +515,10 @@ describe('DB semconv migration', () => {
     );
 
     assert.strictEqual(attributes[ATTR_DB_USER], undefined);
+    assert.strictEqual(
+      attributes[ATTR_DB_SYSTEM_NAME],
+      DB_SYSTEM_NAME_VALUE_ORACLE_DB
+    );
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1_UNIQUE');
     assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
     assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');
@@ -531,6 +539,10 @@ describe('DB semconv migration', () => {
     );
 
     assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
+    assert.strictEqual(
+      attributes[ATTR_DB_SYSTEM_NAME],
+      DB_SYSTEM_NAME_VALUE_ORACLE_DB
+    );
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
     assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
     assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
+import { SemconvStability } from '@opentelemetry/instrumentation';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -25,7 +26,10 @@ import {
 import * as assert from 'assert';
 import { OracleInstrumentation } from '../src';
 import { SpanNames } from '../src/constants';
-import { buildTraceparent } from '../src/OracleTelemetryTraceHandler';
+import {
+  buildTraceparent,
+  getOracleTelemetryTraceHandlerClass,
+} from '../src/OracleTelemetryTraceHandler';
 
 import {
   ATTR_DB_NAMESPACE,
@@ -43,8 +47,15 @@ import {
 import {
   ATTR_DB_OPERATION_PARAMETER,
   ATTR_DB_USER,
+  ATTR_ORACLE_DB_DOMAIN,
+  ATTR_ORACLE_DB_INSTANCE_NAME,
+  ATTR_ORACLE_DB_NAME,
+  ATTR_ORACLE_DB_PDB,
+  ATTR_ORACLE_DB_SERVICE,
   DB_SYSTEM_NAME_VALUE_ORACLE_DB,
 } from '../src/semconv';
+
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
 
 const memoryExporter = new InMemorySpanExporter();
 let contextManager: AsyncLocalStorageContextManager;
@@ -58,6 +69,19 @@ instrumentation.disable();
 
 import * as oracledb from 'oracledb';
 
+function createTestTraceHandler(dbSemconvStability: SemconvStability) {
+  const TraceHandler = getOracleTelemetryTraceHandlerClass({
+    traceHandler: {
+      TraceHandlerBase: class {
+        enable() {}
+      },
+    },
+  } as any);
+  return new TraceHandler(() => tracer, {
+    dbSemconvStability,
+  });
+}
+
 const VER_23_4 = 2304000000;
 const hostname = 'localhost';
 const pno = 1521;
@@ -67,8 +91,8 @@ let numExecSpans = 2; // Default number of Spans created for Execute API in thin
 let numConnSpans = 2; // Default number of spans created during connection establishment.
 let poolMinSpanCount = 1; // number of spans created for createPool considering poolMin.
 const CONFIG = {
-  user: process.env.ORACLE_USER || 'demo',
-  password: process.env.ORACLE_PASSWORD || 'demo',
+  user: process.env.ORACLE_USER || 'vector',
+  password: process.env.ORACLE_PASSWORD || 'vector',
   connectString: process.env.ORACLE_CONNECTSTRING || 'localhost:1521/freepdb1',
 };
 const POOL_CONFIG = {
@@ -104,17 +128,16 @@ let attributesWithSensitiveDataBindsByName: Record<
 let connAttributes: Record<string, string | number>; // connection related span attributes.
 let poolAttributes: Record<string, string | number>; // pool related span attributes.
 let connAttrList: Record<string, string | number>[]; // attributes per span during connection establishment.
-let spanNameSuffix: string; // SpanName will be <operationName serviceName>
+let spanNameSuffix: string; // SpanName will be <operationName db.namespace>
 let failedConnAttrList: Record<string, string | number>[]; // attributes in span for failed connection.
 let poolConnAttrList: Record<string, string | number>[]; // attributes per span when connection established from pool.
 let spanNamesList: string[]; // span names for roundtrips and public API spans.
 
 const DEFAULT_ATTRIBUTES = {
   [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
-  [ATTR_DB_NAMESPACE]: serviceName,
+  [ATTR_ORACLE_DB_SERVICE]: serviceName,
   [ATTR_SERVER_ADDRESS]: hostname,
   [ATTR_SERVER_PORT]: pno,
-  [ATTR_DB_USER]: CONFIG.user,
   [ATTR_NETWORK_TRANSPORT]: 'TCP',
 };
 
@@ -122,18 +145,15 @@ const DEFAULT_ATTRIBUTES = {
 // hostname, port and protocol.
 const DEFAULT_ATTRIBUTES_THICK = {
   [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
-  [ATTR_DB_NAMESPACE]: serviceName,
-  [ATTR_DB_USER]: CONFIG.user,
+  [ATTR_ORACLE_DB_SERVICE]: serviceName,
 };
 
 const POOL_ATTRIBUTES = {
   [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
-  [ATTR_DB_USER]: CONFIG.user,
 };
 
 const CONN_FAILED_ATTRIBUTES = {
   [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_ORACLE_DB,
-  [ATTR_DB_USER]: CONFIG.user,
 };
 
 const unsetStatus: SpanStatus = {
@@ -166,6 +186,8 @@ if (process.env.NODE_ORACLEDB_DRIVER_MODE === 'thick') {
 // Additionally, adjusts the number of roundtrip spans based on the database version.
 function updateAttrSpanList(connection: oracledb.Connection) {
   serverVersion = connection.oracleServerVersion;
+  const extendedConnection = connection as any;
+  const resolvedConnectMetadataAvailableDuringHandshake = oracledb.version < 70000;
 
   let attributes: Record<string, string | number>;
   if (oracledb.thin) {
@@ -177,7 +199,33 @@ function updateAttrSpanList(connection: oracledb.Connection) {
     attributes = { ...DEFAULT_ATTRIBUTES_THICK };
     numExecSpans = 1;
   }
-  attributes[ATTR_DB_NAMESPACE] = `||${connection.serviceName}`;
+  if (resolvedConnectMetadataAvailableDuringHandshake && connection.dbName) {
+    attributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
+  }
+  if (
+    resolvedConnectMetadataAvailableDuringHandshake &&
+    extendedConnection.domainName
+  ) {
+    attributes[ATTR_ORACLE_DB_DOMAIN] = extendedConnection.domainName;
+  }
+  if (
+    resolvedConnectMetadataAvailableDuringHandshake &&
+    extendedConnection.pdbName
+  ) {
+    attributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
+  }
+  if (
+    resolvedConnectMetadataAvailableDuringHandshake &&
+    connection.serviceName
+  ) {
+    attributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
+  }
+  if (
+    resolvedConnectMetadataAvailableDuringHandshake &&
+    extendedConnection.dbUniqueName
+  ) {
+    attributes[ATTR_DB_NAMESPACE] = `${extendedConnection.dbUniqueName}`;
+  }
 
   // initialize the span attributes list.
   connAttrList = [];
@@ -288,10 +336,6 @@ function checkRoundTripSpans(
   }
 }
 
-function getDBNameSpace(instanceName = '', pdbName = '', servicename = '') {
-  return [instanceName, pdbName, servicename].join('|');
-}
-
 // It verifies the spans, its attributes and the parent child relationship.
 function verifySpans(
   parentSpan: Span | null,
@@ -394,6 +438,66 @@ const sqlCreateTable = async function (
   await conn.execute(plsql);
 };
 
+describe('DB semconv migration', () => {
+  const connectionConfig = {
+    user: 'vector',
+    protocol: 'TCP',
+    hostName: 'localhost',
+    port: 1521,
+    dbName: 'ORCL',
+    instanceName: 'ORCL1',
+    pdbName: 'PDB1',
+    domainName: 'example.com',
+    serviceName: 'svc',
+    dbUniqueName: 'ORCL1_UNIQUE',
+  };
+
+  it('keeps old db.namespace semantics and db.user by default', () => {
+    const handler = createTestTraceHandler(SemconvStability.OLD);
+    const attributes = (handler as any)._getConnectionSpanAttributes(
+      connectionConfig
+    );
+
+    assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
+    assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], undefined);
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], undefined);
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_DOMAIN], undefined);
+  });
+
+  it('emits new db.namespace semantics and removes db.user in stable mode', () => {
+    const handler = createTestTraceHandler(SemconvStability.STABLE);
+    const attributes = (handler as any)._getConnectionSpanAttributes(
+      connectionConfig
+    );
+
+    assert.strictEqual(attributes[ATTR_DB_USER], undefined);
+    assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1_UNIQUE');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], 'ORCL');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_INSTANCE_NAME], 'ORCL1');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], 'PDB1');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_DOMAIN], 'example.com');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_SERVICE], 'svc');
+  });
+
+  it('keeps old db.namespace in dup mode while emitting new oracle.db attributes', () => {
+    const handler = createTestTraceHandler(
+      SemconvStability.OLD | SemconvStability.STABLE
+    );
+    const attributes = (handler as any)._getConnectionSpanAttributes(
+      connectionConfig
+    );
+
+    assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
+    assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], 'ORCL');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_INSTANCE_NAME], 'ORCL1');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], 'PDB1');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_DOMAIN], 'example.com');
+    assert.strictEqual(attributes[ATTR_ORACLE_DB_SERVICE], 'svc');
+  });
+});
+
 describe('oracledb', () => {
   let connection: oracledb.Connection;
 
@@ -413,7 +517,6 @@ describe('oracledb', () => {
 
   async function doSetup() {
     const extendedConn: any = connection;
-    let dbName;
 
     if (oracledb.thin) {
       connAttributes = { ...DEFAULT_ATTRIBUTES };
@@ -430,15 +533,23 @@ describe('oracledb', () => {
       connAttributes[ATTR_NETWORK_TRANSPORT] = extendedConn.protocol;
     }
     if (connection.dbName) {
-      dbName = oracledb.thin
+      connAttributes[ATTR_ORACLE_DB_NAME] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
     }
-    connAttributes[ATTR_DB_NAMESPACE] = getDBNameSpace(
-      connection.instanceName,
-      dbName,
-      connection.serviceName
-    );
+    if (extendedConn.domainName) {
+      connAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConn.domainName;
+    }
+    if (connection.instanceName) {
+      connAttributes[ATTR_ORACLE_DB_INSTANCE_NAME] = connection.instanceName;
+    }
+    if (extendedConn.pdbName) {
+      connAttributes[ATTR_ORACLE_DB_PDB] = extendedConn.pdbName;
+    }
+    if (connection.serviceName) {
+      connAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
+    }
+    connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
     poolAttributes = { ...connAttributes, ...POOL_ATTRIBUTES };
 
     executeAttributes = {
@@ -1317,6 +1428,10 @@ describe('oracledb', () => {
         { a: 5, b: 'Test 5 (Five)' },
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
+      const executeManyAttributes = {
+        ...connAttributes,
+        [ATTR_DB_OPERATION_NAME]: 'INSERT',
+      };
 
       await context.with(trace.setSpan(context.active(), span), async () => {
         const res = await connection.executeMany<Array<string>>(
@@ -1327,10 +1442,10 @@ describe('oracledb', () => {
           assert.ok(res);
           verifySpans(
             span,
-            [connAttributes, connAttributes],
+            [executeManyAttributes, executeManyAttributes],
             [
-              SpanNames.EXECUTE_MSG + ':' + spanNameSuffix,
-              SpanNames.EXECUTE_MANY + ':' + spanNameSuffix,
+              SpanNames.EXECUTE_MSG + ':INSERT' + spanNameSuffix,
+              SpanNames.EXECUTE_MANY + ':INSERT' + spanNameSuffix,
             ]
           );
         } catch (e: any) {
@@ -1352,15 +1467,19 @@ describe('oracledb', () => {
         { a: 5, b: 'Test 5 (Five)' },
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
+      const executeManyAttributes = {
+        ...connAttributes,
+        [ATTR_DB_OPERATION_NAME]: 'INSERT',
+      };
       const res = await connection.executeMany<Array<string>>(sqlInsert, binds);
       try {
         assert.ok(res);
         verifySpans(
           null,
-          [connAttributes, connAttributes],
+          [executeManyAttributes, executeManyAttributes],
           [
-            SpanNames.EXECUTE_MSG + ':' + spanNameSuffix,
-            SpanNames.EXECUTE_MANY + ':' + spanNameSuffix,
+            SpanNames.EXECUTE_MSG + ':INSERT' + spanNameSuffix,
+            SpanNames.EXECUTE_MANY + ':INSERT' + spanNameSuffix,
           ]
         );
       } catch (e: any) {

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -55,17 +55,13 @@ import {
   DB_SYSTEM_NAME_VALUE_ORACLE_DB,
 } from '../src/semconv';
 
-process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
-
 const memoryExporter = new InMemorySpanExporter();
 let contextManager: AsyncLocalStorageContextManager;
 const provider = new BasicTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
 const tracer = provider.getTracer('external');
-const instrumentation = new OracleInstrumentation();
-instrumentation.enable();
-instrumentation.disable();
+let instrumentation: OracleInstrumentation;
 
 import * as oracledb from 'oracledb';
 
@@ -91,8 +87,8 @@ let numExecSpans = 2; // Default number of Spans created for Execute API in thin
 let numConnSpans = 2; // Default number of spans created during connection establishment.
 let poolMinSpanCount = 1; // number of spans created for createPool considering poolMin.
 const CONFIG = {
-  user: process.env.ORACLE_USER || 'vector',
-  password: process.env.ORACLE_PASSWORD || 'vector',
+  user: process.env.ORACLE_USER || 'demo',
+  password: process.env.ORACLE_PASSWORD || 'demo',
   connectString: process.env.ORACLE_CONNECTSTRING || 'localhost:1521/freepdb1',
 };
 const POOL_CONFIG = {
@@ -439,6 +435,21 @@ const sqlCreateTable = async function (
 };
 
 describe('DB semconv migration', () => {
+  let oldEnv: string | undefined;
+
+  before(() => {
+    oldEnv = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
+  });
+
+  after(() => {
+    if (oldEnv === undefined) {
+      delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    } else {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = oldEnv;
+    }
+  });
+
   const connectionConfig = {
     user: 'vector',
     protocol: 'TCP',
@@ -500,6 +511,7 @@ describe('DB semconv migration', () => {
 
 describe('oracledb', () => {
   let connection: oracledb.Connection;
+  const originalDbSemconvOptIn = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
 
   const testOracleDB = process.env.RUN_ORACLEDB_TESTS; // For CI: assumes local oracledb is already available
   const shouldTest = testOracleDB; // Skips these tests if false (default)
@@ -596,6 +608,8 @@ describe('oracledb', () => {
       skip();
     }
 
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
+    instrumentation = new OracleInstrumentation();
     connection = await oracledb.getConnection(CONFIG);
     await doSetup();
     updateAttrSpanList(connection);
@@ -611,6 +625,7 @@ describe('oracledb', () => {
       await connection.close();
     }
     instrumentation.disable();
+    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = originalDbSemconvOptIn;
   });
 
   beforeEach(() => {

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -100,6 +100,22 @@ function isOracleDB610(): boolean {
   return oracledb.version === 61000;
 }
 
+function hasSeparateDbName(): boolean {
+  return oracledb.version >= 70000;
+}
+
+function hasPdbName(): boolean {
+  return oracledb.version >= 70000;
+}
+
+function hasDbUniqueName(): boolean {
+  return oracledb.version >= 70000;
+}
+
+function hasExecuteManySqlOperation(): boolean {
+  return oracledb.version >= 70000;
+}
+
 let serverVersion = 2304000000; // DB version.
 let numExecSpans = 2; // Default number of Spans created for Execute API in thin mode.
 let numConnSpans = 2; // Default number of spans created during connection establishment.
@@ -218,7 +234,7 @@ function updateAttrSpanList(connection: oracledb.Connection) {
     connectSpanAttributes[ATTR_ORACLE_DB_INSTANCE_NAME] =
       connection.instanceName;
   }
-  if (extendedConnection.pdbName) {
+  if (hasPdbName() && extendedConnection.pdbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
   } else if (isOracleDB610() && connection.dbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = connection.dbName;
@@ -226,13 +242,13 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   if (connection.serviceName) {
     connectSpanAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
   }
-  if (!isOracleDB610() && connection.dbName) {
+  if (hasSeparateDbName() && connection.dbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
   }
-  if (!isOracleDB610() && extendedConnection.domainName) {
+  if (extendedConnection.domainName) {
     connectSpanAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConnection.domainName;
   }
-  if (!isOracleDB610() && extendedConnection.dbUniqueName) {
+  if (hasDbUniqueName() && extendedConnection.dbUniqueName) {
     connectSpanAttributes[ATTR_DB_NAMESPACE] = `${extendedConnection.dbUniqueName}`;
   }
 
@@ -552,18 +568,18 @@ describe('oracledb', () => {
     if (oracledb.thin && extendedConn.protocol) {
       connAttributes[ATTR_NETWORK_TRANSPORT] = extendedConn.protocol;
     }
-    if (connection.dbName && !isOracleDB610()) {
+    if (connection.dbName && hasSeparateDbName()) {
       connAttributes[ATTR_ORACLE_DB_NAME] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
     }
-    if (extendedConn.domainName && !isOracleDB610()) {
+    if (extendedConn.domainName) {
       connAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConn.domainName;
     }
     if (connection.instanceName) {
       connAttributes[ATTR_ORACLE_DB_INSTANCE_NAME] = connection.instanceName;
     }
-    if (extendedConn.pdbName) {
+    if (hasPdbName() && extendedConn.pdbName) {
       connAttributes[ATTR_ORACLE_DB_PDB] = extendedConn.pdbName;
     } else if (connection.dbName && isOracleDB610()) {
       connAttributes[ATTR_ORACLE_DB_PDB] = oracledb.thin
@@ -573,7 +589,7 @@ describe('oracledb', () => {
     if (connection.serviceName) {
       connAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
     }
-    if (extendedConn.dbUniqueName && !isOracleDB610()) {
+    if (hasDbUniqueName() && extendedConn.dbUniqueName) {
       connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
     }
     poolAttributes = { ...connAttributes, ...POOL_ATTRIBUTES };
@@ -1446,9 +1462,9 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds)', async () => {
       const span = tracer.startSpan('test span');
-      const executeManyRoundTripCommand = isOracleDB610()
-        ? ''
-        : 'INSERT';
+      const executeManyRoundTripCommand = hasExecuteManySqlOperation()
+        ? 'INSERT'
+        : '';
       const executeManyPublicCommand = 'INSERT';
       const binds = [
         { a: 1, b: 'Test 1 (One)' },
@@ -1459,7 +1475,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!isOracleDB610()) {
+      if (hasExecuteManySqlOperation()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
 
@@ -1493,9 +1509,9 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds) with out parent span', async () => {
       instrumentation.enable();
-      const executeManyRoundTripCommand = isOracleDB610()
-        ? ''
-        : 'INSERT';
+      const executeManyRoundTripCommand = hasExecuteManySqlOperation()
+        ? 'INSERT'
+        : '';
       const executeManyPublicCommand = 'INSERT';
       const binds = [
         { a: 1, b: 'Test 1 (One)' },
@@ -1506,7 +1522,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!isOracleDB610()) {
+      if (hasExecuteManySqlOperation()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
       const res = await connection.executeMany<Array<string>>(sqlInsert, binds);

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -61,11 +61,24 @@ const provider = new BasicTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
 const tracer = provider.getTracer('external');
-let instrumentation: OracleInstrumentation;
+// Prime the module patch path in stable mode for integration tests using the
+// public env-based semconv selection path, then restore the process env.
+const oldDbSemconvOptIn = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
+const instrumentation = new OracleInstrumentation();
+if (oldDbSemconvOptIn === undefined) {
+  delete process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+} else {
+  process.env.OTEL_SEMCONV_STABILITY_OPT_IN = oldDbSemconvOptIn;
+}
+instrumentation.enable();
+instrumentation.disable();
 
 import * as oracledb from 'oracledb';
 
-function createTestTraceHandler(dbSemconvStability: SemconvStability) {
+function createTestTraceHandlerForSemconvTests(
+  dbSemconvStability: SemconvStability
+) {
   const TraceHandler = getOracleTelemetryTraceHandlerClass({
     traceHandler: {
       TraceHandlerBase: class {
@@ -183,7 +196,10 @@ if (process.env.NODE_ORACLEDB_DRIVER_MODE === 'thick') {
 function updateAttrSpanList(connection: oracledb.Connection) {
   serverVersion = connection.oracleServerVersion;
   const extendedConnection = connection as any;
-  const resolvedConnectMetadataAvailableDuringHandshake = oracledb.version < 70000;
+  const usesLegacyStableMetadataShape = oracledb.version <= 61000;
+  const resolvedConnectMetadataAvailableDuringHandshake =
+    oracledb.version < 61000;
+  const connectSpanAttributes: Record<string, string | number> = {};
 
   let attributes: Record<string, string | number>;
   if (oracledb.thin) {
@@ -195,32 +211,37 @@ function updateAttrSpanList(connection: oracledb.Connection) {
     attributes = { ...DEFAULT_ATTRIBUTES_THICK };
     numExecSpans = 1;
   }
-  if (resolvedConnectMetadataAvailableDuringHandshake && connection.dbName) {
-    attributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
+  Object.assign(connectSpanAttributes, attributes);
+  if (connection.instanceName) {
+    connectSpanAttributes[ATTR_ORACLE_DB_INSTANCE_NAME] =
+      connection.instanceName;
+  }
+  if (extendedConnection.pdbName) {
+    connectSpanAttributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
+  } else if (usesLegacyStableMetadataShape && connection.dbName) {
+    connectSpanAttributes[ATTR_ORACLE_DB_PDB] = connection.dbName;
+  }
+  if (connection.serviceName) {
+    connectSpanAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
+  }
+  if (
+    resolvedConnectMetadataAvailableDuringHandshake &&
+    !usesLegacyStableMetadataShape &&
+    connection.dbName
+  ) {
+    connectSpanAttributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
   }
   if (
     resolvedConnectMetadataAvailableDuringHandshake &&
     extendedConnection.domainName
   ) {
-    attributes[ATTR_ORACLE_DB_DOMAIN] = extendedConnection.domainName;
-  }
-  if (
-    resolvedConnectMetadataAvailableDuringHandshake &&
-    extendedConnection.pdbName
-  ) {
-    attributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
-  }
-  if (
-    resolvedConnectMetadataAvailableDuringHandshake &&
-    connection.serviceName
-  ) {
-    attributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
+    connectSpanAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConnection.domainName;
   }
   if (
     resolvedConnectMetadataAvailableDuringHandshake &&
     extendedConnection.dbUniqueName
   ) {
-    attributes[ATTR_DB_NAMESPACE] = `${extendedConnection.dbUniqueName}`;
+    connectSpanAttributes[ATTR_DB_NAMESPACE] = `${extendedConnection.dbUniqueName}`;
   }
 
   // initialize the span attributes list.
@@ -228,7 +249,9 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   poolConnAttrList = [];
   spanNamesList = [];
   failedConnAttrList = [];
-  spanNameSuffix = ` ${connAttributes[ATTR_DB_NAMESPACE]}`;
+  spanNameSuffix = connAttributes[ATTR_DB_NAMESPACE]
+    ? ` ${connAttributes[ATTR_DB_NAMESPACE]}`
+    : '';
   if (serverVersion >= VER_23_4) {
     if (oracledb.thin) {
       // for round trips.
@@ -265,8 +288,8 @@ function updateAttrSpanList(connection: oracledb.Connection) {
         connAttrList.push({ ...attributes });
         poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
       } else {
-        connAttrList.push({ ...connAttributes });
-        poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES });
+        connAttrList.push({ ...connectSpanAttributes });
+        poolConnAttrList.push({ ...connectSpanAttributes, ...POOL_ATTRIBUTES });
       }
       failedConnAttrList = [...connAttrList];
       failedConnAttrList[4] = { ...CONN_FAILED_ATTRIBUTES };
@@ -464,7 +487,9 @@ describe('DB semconv migration', () => {
   };
 
   it('keeps old db.namespace semantics and db.user by default', () => {
-    const handler = createTestTraceHandler(SemconvStability.OLD);
+    const handler = createTestTraceHandlerForSemconvTests(
+      SemconvStability.OLD
+    );
     const attributes = (handler as any)._getConnectionSpanAttributes(
       connectionConfig
     );
@@ -477,7 +502,9 @@ describe('DB semconv migration', () => {
   });
 
   it('emits new db.namespace semantics and removes db.user in stable mode', () => {
-    const handler = createTestTraceHandler(SemconvStability.STABLE);
+    const handler = createTestTraceHandlerForSemconvTests(
+      SemconvStability.STABLE
+    );
     const attributes = (handler as any)._getConnectionSpanAttributes(
       connectionConfig
     );
@@ -492,7 +519,7 @@ describe('DB semconv migration', () => {
   });
 
   it('keeps old db.namespace in dup mode while emitting new oracle.db attributes', () => {
-    const handler = createTestTraceHandler(
+    const handler = createTestTraceHandlerForSemconvTests(
       SemconvStability.OLD | SemconvStability.STABLE
     );
     const attributes = (handler as any)._getConnectionSpanAttributes(
@@ -511,7 +538,6 @@ describe('DB semconv migration', () => {
 
 describe('oracledb', () => {
   let connection: oracledb.Connection;
-  const originalDbSemconvOptIn = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
 
   const testOracleDB = process.env.RUN_ORACLEDB_TESTS; // For CI: assumes local oracledb is already available
   const shouldTest = testOracleDB; // Skips these tests if false (default)
@@ -529,6 +555,7 @@ describe('oracledb', () => {
 
   async function doSetup() {
     const extendedConn: any = connection;
+    const usesLegacyStableMetadataShape = oracledb.version <= 61000;
 
     if (oracledb.thin) {
       connAttributes = { ...DEFAULT_ATTRIBUTES };
@@ -544,12 +571,12 @@ describe('oracledb', () => {
     if (oracledb.thin && extendedConn.protocol) {
       connAttributes[ATTR_NETWORK_TRANSPORT] = extendedConn.protocol;
     }
-    if (connection.dbName) {
+    if (connection.dbName && !usesLegacyStableMetadataShape) {
       connAttributes[ATTR_ORACLE_DB_NAME] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
     }
-    if (extendedConn.domainName) {
+    if (extendedConn.domainName && !usesLegacyStableMetadataShape) {
       connAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConn.domainName;
     }
     if (connection.instanceName) {
@@ -557,11 +584,17 @@ describe('oracledb', () => {
     }
     if (extendedConn.pdbName) {
       connAttributes[ATTR_ORACLE_DB_PDB] = extendedConn.pdbName;
+    } else if (connection.dbName && usesLegacyStableMetadataShape) {
+      connAttributes[ATTR_ORACLE_DB_PDB] = oracledb.thin
+        ? connection.dbName.toUpperCase()
+        : connection.dbName;
     }
     if (connection.serviceName) {
       connAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
     }
-    connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
+    if (extendedConn.dbUniqueName && !usesLegacyStableMetadataShape) {
+      connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
+    }
     poolAttributes = { ...connAttributes, ...POOL_ATTRIBUTES };
 
     executeAttributes = {
@@ -608,8 +641,6 @@ describe('oracledb', () => {
       skip();
     }
 
-    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
-    instrumentation = new OracleInstrumentation();
     connection = await oracledb.getConnection(CONFIG);
     await doSetup();
     updateAttrSpanList(connection);
@@ -625,7 +656,6 @@ describe('oracledb', () => {
       await connection.close();
     }
     instrumentation.disable();
-    process.env.OTEL_SEMCONV_STABILITY_OPT_IN = originalDbSemconvOptIn;
   });
 
   beforeEach(() => {
@@ -1435,6 +1465,11 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds)', async () => {
       const span = tracer.startSpan('test span');
+      const usesLegacyStableMetadataShape = oracledb.version <= 61000;
+      const executeManyRoundTripCommand = usesLegacyStableMetadataShape
+        ? ''
+        : 'INSERT';
+      const executeManyPublicCommand = 'INSERT';
       const binds = [
         { a: 1, b: 'Test 1 (One)' },
         { a: 2, b: 'Test 2 (Two)' },
@@ -1443,10 +1478,10 @@ describe('oracledb', () => {
         { a: 5, b: 'Test 5 (Five)' },
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
-      const executeManyAttributes = {
-        ...connAttributes,
-        [ATTR_DB_OPERATION_NAME]: 'INSERT',
-      };
+      const executeManyAttributes = { ...connAttributes };
+      if (!usesLegacyStableMetadataShape) {
+        executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
+      }
 
       await context.with(trace.setSpan(context.active(), span), async () => {
         const res = await connection.executeMany<Array<string>>(
@@ -1459,8 +1494,12 @@ describe('oracledb', () => {
             span,
             [executeManyAttributes, executeManyAttributes],
             [
-              SpanNames.EXECUTE_MSG + ':INSERT' + spanNameSuffix,
-              SpanNames.EXECUTE_MANY + ':INSERT' + spanNameSuffix,
+              SpanNames.EXECUTE_MSG +
+                `:${executeManyRoundTripCommand}` +
+                spanNameSuffix,
+              SpanNames.EXECUTE_MANY +
+                `:${executeManyPublicCommand}` +
+                spanNameSuffix,
             ]
           );
         } catch (e: any) {
@@ -1474,6 +1513,11 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds) with out parent span', async () => {
       instrumentation.enable();
+      const usesLegacyStableMetadataShape = oracledb.version <= 61000;
+      const executeManyRoundTripCommand = usesLegacyStableMetadataShape
+        ? ''
+        : 'INSERT';
+      const executeManyPublicCommand = 'INSERT';
       const binds = [
         { a: 1, b: 'Test 1 (One)' },
         { a: 2, b: 'Test 2 (Two)' },
@@ -1482,10 +1526,10 @@ describe('oracledb', () => {
         { a: 5, b: 'Test 5 (Five)' },
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
-      const executeManyAttributes = {
-        ...connAttributes,
-        [ATTR_DB_OPERATION_NAME]: 'INSERT',
-      };
+      const executeManyAttributes = { ...connAttributes };
+      if (!usesLegacyStableMetadataShape) {
+        executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
+      }
       const res = await connection.executeMany<Array<string>>(sqlInsert, binds);
       try {
         assert.ok(res);
@@ -1493,8 +1537,12 @@ describe('oracledb', () => {
           null,
           [executeManyAttributes, executeManyAttributes],
           [
-            SpanNames.EXECUTE_MSG + ':INSERT' + spanNameSuffix,
-            SpanNames.EXECUTE_MANY + ':INSERT' + spanNameSuffix,
+            SpanNames.EXECUTE_MSG +
+              `:${executeManyRoundTripCommand}` +
+              spanNameSuffix,
+            SpanNames.EXECUTE_MANY +
+              `:${executeManyPublicCommand}` +
+              spanNameSuffix,
           ]
         );
       } catch (e: any) {

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -61,8 +61,8 @@ const provider = new BasicTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
 const tracer = provider.getTracer('external');
-// Prime the module patch path in stable mode for integration tests using the
-// public env-based semconv selection path, then restore the process env.
+
+// We create instrumentation with stability as 'database' and restore the env.
 const oldDbSemconvOptIn = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
 process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database';
 const instrumentation = new OracleInstrumentation();
@@ -95,6 +95,11 @@ const VER_23_4 = 2304000000;
 const hostname = 'localhost';
 const pno = 1521;
 const serviceName = 'FREEPDB1';
+
+function isOracleDBPre7(): boolean {
+  return oracledb.version <= 61000;
+}
+
 let serverVersion = 2304000000; // DB version.
 let numExecSpans = 2; // Default number of Spans created for Execute API in thin mode.
 let numConnSpans = 2; // Default number of spans created during connection establishment.
@@ -196,7 +201,6 @@ if (process.env.NODE_ORACLEDB_DRIVER_MODE === 'thick') {
 function updateAttrSpanList(connection: oracledb.Connection) {
   serverVersion = connection.oracleServerVersion;
   const extendedConnection = connection as any;
-  const usesLegacyStableMetadataShape = oracledb.version <= 61000;
   const resolvedConnectMetadataAvailableDuringHandshake =
     oracledb.version < 61000;
   const connectSpanAttributes: Record<string, string | number> = {};
@@ -218,7 +222,7 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   }
   if (extendedConnection.pdbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = extendedConnection.pdbName;
-  } else if (usesLegacyStableMetadataShape && connection.dbName) {
+  } else if (isOracleDBPre7() && connection.dbName) {
     connectSpanAttributes[ATTR_ORACLE_DB_PDB] = connection.dbName;
   }
   if (connection.serviceName) {
@@ -226,7 +230,7 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   }
   if (
     resolvedConnectMetadataAvailableDuringHandshake &&
-    !usesLegacyStableMetadataShape &&
+    !isOracleDBPre7() &&
     connection.dbName
   ) {
     connectSpanAttributes[ATTR_ORACLE_DB_NAME] = connection.dbName;
@@ -555,7 +559,6 @@ describe('oracledb', () => {
 
   async function doSetup() {
     const extendedConn: any = connection;
-    const usesLegacyStableMetadataShape = oracledb.version <= 61000;
 
     if (oracledb.thin) {
       connAttributes = { ...DEFAULT_ATTRIBUTES };
@@ -571,12 +574,12 @@ describe('oracledb', () => {
     if (oracledb.thin && extendedConn.protocol) {
       connAttributes[ATTR_NETWORK_TRANSPORT] = extendedConn.protocol;
     }
-    if (connection.dbName && !usesLegacyStableMetadataShape) {
+    if (connection.dbName && !isOracleDBPre7()) {
       connAttributes[ATTR_ORACLE_DB_NAME] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
     }
-    if (extendedConn.domainName && !usesLegacyStableMetadataShape) {
+    if (extendedConn.domainName && !isOracleDBPre7()) {
       connAttributes[ATTR_ORACLE_DB_DOMAIN] = extendedConn.domainName;
     }
     if (connection.instanceName) {
@@ -584,7 +587,7 @@ describe('oracledb', () => {
     }
     if (extendedConn.pdbName) {
       connAttributes[ATTR_ORACLE_DB_PDB] = extendedConn.pdbName;
-    } else if (connection.dbName && usesLegacyStableMetadataShape) {
+    } else if (connection.dbName && isOracleDBPre7()) {
       connAttributes[ATTR_ORACLE_DB_PDB] = oracledb.thin
         ? connection.dbName.toUpperCase()
         : connection.dbName;
@@ -592,7 +595,7 @@ describe('oracledb', () => {
     if (connection.serviceName) {
       connAttributes[ATTR_ORACLE_DB_SERVICE] = connection.serviceName;
     }
-    if (extendedConn.dbUniqueName && !usesLegacyStableMetadataShape) {
+    if (extendedConn.dbUniqueName && !isOracleDBPre7()) {
       connAttributes[ATTR_DB_NAMESPACE] = extendedConn.dbUniqueName;
     }
     poolAttributes = { ...connAttributes, ...POOL_ATTRIBUTES };
@@ -1465,8 +1468,7 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds)', async () => {
       const span = tracer.startSpan('test span');
-      const usesLegacyStableMetadataShape = oracledb.version <= 61000;
-      const executeManyRoundTripCommand = usesLegacyStableMetadataShape
+      const executeManyRoundTripCommand = isOracleDBPre7()
         ? ''
         : 'INSERT';
       const executeManyPublicCommand = 'INSERT';
@@ -1479,7 +1481,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!usesLegacyStableMetadataShape) {
+      if (!isOracleDBPre7()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
 
@@ -1513,8 +1515,7 @@ describe('oracledb', () => {
 
     it('should intercept connection.executeMany(sql, binds) with out parent span', async () => {
       instrumentation.enable();
-      const usesLegacyStableMetadataShape = oracledb.version <= 61000;
-      const executeManyRoundTripCommand = usesLegacyStableMetadataShape
+      const executeManyRoundTripCommand = isOracleDBPre7()
         ? ''
         : 'INSERT';
       const executeManyPublicCommand = 'INSERT';
@@ -1527,7 +1528,7 @@ describe('oracledb', () => {
       ];
       const sqlInsert = `INSERT INTO ${tableName} VALUES (:a, :b, 'clob')`;
       const executeManyAttributes = { ...connAttributes };
-      if (!usesLegacyStableMetadataShape) {
+      if (!isOracleDBPre7()) {
         executeManyAttributes[ATTR_DB_OPERATION_NAME] = 'INSERT';
       }
       const res = await connection.executeMany<Array<string>>(sqlInsert, binds);

--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -494,6 +494,9 @@ describe('DB semconv migration', () => {
 
     assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
+    assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
+    assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');
+    assert.strictEqual(attributes[ATTR_SERVER_PORT], 1521);
     assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], undefined);
     assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], undefined);
     assert.strictEqual(attributes[ATTR_ORACLE_DB_DOMAIN], undefined);
@@ -509,6 +512,9 @@ describe('DB semconv migration', () => {
 
     assert.strictEqual(attributes[ATTR_DB_USER], undefined);
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1_UNIQUE');
+    assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
+    assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');
+    assert.strictEqual(attributes[ATTR_SERVER_PORT], 1521);
     assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], 'ORCL');
     assert.strictEqual(attributes[ATTR_ORACLE_DB_INSTANCE_NAME], 'ORCL1');
     assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], 'PDB1');
@@ -526,6 +532,9 @@ describe('DB semconv migration', () => {
 
     assert.strictEqual(attributes[ATTR_DB_USER], 'vector');
     assert.strictEqual(attributes[ATTR_DB_NAMESPACE], 'ORCL1|PDB1|svc');
+    assert.strictEqual(attributes[ATTR_NETWORK_TRANSPORT], 'TCP');
+    assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'localhost');
+    assert.strictEqual(attributes[ATTR_SERVER_PORT], 1521);
     assert.strictEqual(attributes[ATTR_ORACLE_DB_NAME], 'ORCL');
     assert.strictEqual(attributes[ATTR_ORACLE_DB_INSTANCE_NAME], 'ORCL1');
     assert.strictEqual(attributes[ATTR_ORACLE_DB_PDB], 'PDB1');


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

-

## Short description of the changes

Summary of Changes
1. Version Upgrades & Compatibility (package.json, instrumentation.ts)
Upgrades the oracledb devDependency from ^6.7.0 to ^7.0.0.

Updates the supported oracledb module range in the instrumentation definition from ['>= 6.7 < 7'] to ['>= 6.7 < 8'] to officially support version 7.x.

2. Environment-Driven Semconv Stability Opt-In (instrumentation.ts)
Introduces the internal tracking of database semantic convention stability via this._dbSemconvStability.

Reads the opt-in configuration from the standard environment variable: process.env.OTEL_SEMCONV_STABILITY_OPT_IN.

Passes this stability config down to the OracleTelemetryTraceHandler instance via internal configuration spread (dbSemconvStability).

3. Conditional Attribute Emission (OracleTelemetryTraceHandler.ts, semconv.ts, types.ts)
The _getConnectionSpanAttributes method has been refactored to check whether it should output old attributes, stable attributes, or both (duplicate mode) depending on the active semconv state:

OLD mode: * Preserves the standard db.user attribute.

Emits the legacy db.namespace using the combined piping format (instanceName|pdbName|serviceName).

STABLE mode:

Removes db.user (complying with the stable specification).

Updates db.namespace to single out dbUniqueName.

Emits specific namespace prefixed namespaces/attributes: oracle.db.name, oracle.db.domain, oracle.db.pdb, oracle.db.instance.name, and oracle.db.service.

Duplicate / Hybrid Mode: * If both modes are active, db.namespace maintains its legacy format to prevent collision, but all the new stable oracle.db.* attributes are emitted alongside it.

4. Span Naming Update (OracleTelemetryTraceHandler.ts)
The logic that updates span names via userContext.span.updateName shifts its behavior based on stable conventions. It now opts for connectLevelConfig.dbUniqueName in stable mode, falling back to the old joined namespace format otherwise.

5. Testing Framework Expansion (oracle.test.ts)
Forces process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database' within tests to ensure coverage of the migration behaviors.

Adds a dedicated describe('DB semconv migration') suite that validates all 3 matrix legs:

Default / Legacy old behavior retention.

New stable emission (with structural removals like db.user).

Duplicate coexistence mode stability verification.

Fixes existing assert expectations for executeMany tests to account for updated span naming prefixes (e.g., adding explicit operation hooks like :INSERT).



Old mode:keep old db.namespace
keep db.user
db.system.name / db.query.text can still appear if the instrumentation already uses them generically

Stable mode:remove db.user
switch db.namespace to DB_UNIQUE_NAME
add oracle.db.* attrs

Dup mode:keep old db.namespace
add oracle.db.*

